### PR TITLE
fix: fix scrolling after submitting a prompt

### DIFF
--- a/src/routes/sessions/[id]/+page.svelte
+++ b/src/routes/sessions/[id]/+page.svelte
@@ -172,9 +172,7 @@
 	async function scrollToBottom(shouldForceScroll = false) {
 		if (!shouldForceScroll && (!messageWindow || userScrolledUp)) return;
 		await tick();
-		requestAnimationFrame(() => {
-			messageWindow.scrollTop = messageWindow.scrollHeight;
-		});
+		requestAnimationFrame(() => (messageWindow.scrollTop = messageWindow.scrollHeight));
 	}
 
 	function handleError(error: Error) {

--- a/src/routes/sessions/[id]/+page.svelte
+++ b/src/routes/sessions/[id]/+page.svelte
@@ -172,7 +172,9 @@
 	async function scrollToBottom(shouldForceScroll = false) {
 		if (!shouldForceScroll && (!messageWindow || userScrolledUp)) return;
 		await tick();
-		messageWindow.scrollTop = messageWindow.scrollHeight;
+		setTimeout(() => {
+			messageWindow.scrollTop = messageWindow.scrollHeight;
+		}, 50);
 	}
 
 	function handleError(error: Error) {

--- a/src/routes/sessions/[id]/+page.svelte
+++ b/src/routes/sessions/[id]/+page.svelte
@@ -172,9 +172,9 @@
 	async function scrollToBottom(shouldForceScroll = false) {
 		if (!shouldForceScroll && (!messageWindow || userScrolledUp)) return;
 		await tick();
-		setTimeout(() => {
+		requestAnimationFrame(() => {
 			messageWindow.scrollTop = messageWindow.scrollHeight;
-		}, 50);
+		});
 	}
 
 	function handleError(error: Error) {


### PR DESCRIPTION
@fmaclen I found the problem. This bug is happening because `handleCompletion` sets `isCompletionInProgress` to `true`, which makes the `...` message visible:

```svelte
{#if isCompletionInProgress}
  <Article message={{ role: 'assistant', content: completion || '...' }} />
{/if}
```

It seems that this render occurs after the `scrollToBottom` invocation. 

I fixed it by using the `requestAnimationFrame` [function](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame), which schedules the scroll action to occur in the next frame after the browser has completed its current rendering tasks.