### PR TITLE
chore: add VSCode debuggers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,45 +1,45 @@
 {
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Debug current TS file",
-      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/vite-node",
-      "args": ["${relativeFile}"],
-      "cwd": "${workspaceFolder}",
-      "internalConsoleOptions": "openOnSessionStart",
-      "skipFiles": ["<node_internals>/**", "node_modules/**"],
-      "env": {
-        "TS_NODE_PROJECT": "${workspaceFolder}/tsconfig.json"
-      }
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Start vite",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev", "--", "--port", "4000"],
-      "skipFiles": ["<node_internals>/**"],
-      "console": "integratedTerminal"
-    },
-    {
-      "type": "chrome",
-      "request": "launch",
-      "name": "Launch Chrome",
-      "url": "http://localhost:4000",
-      "webRoot": "${workspaceFolder}",
-      "sourceMaps": true,
-      "sourceMapPathOverrides": {
-        "webpack:///./src/*": "${webRoot}/src/*"
-      },
-      "runtimeArgs": ["--auto-open-devtools-for-tabs"]
-    }
-  ],
-  "compounds": [
-    {
-      "name": "Debug SvelteKit",
-      "configurations": ["Start vite", "Launch Chrome"]
-    }
-  ]
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Debug current TS file",
+			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/vite-node",
+			"args": ["${relativeFile}"],
+			"cwd": "${workspaceFolder}",
+			"internalConsoleOptions": "openOnSessionStart",
+			"skipFiles": ["<node_internals>/**", "node_modules/**"],
+			"env": {
+				"TS_NODE_PROJECT": "${workspaceFolder}/tsconfig.json"
+			}
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Start vite",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": ["run", "dev", "--", "--port", "4000"],
+			"skipFiles": ["<node_internals>/**"],
+			"console": "integratedTerminal"
+		},
+		{
+			"type": "chrome",
+			"request": "launch",
+			"name": "Launch Chrome",
+			"url": "http://localhost:4000",
+			"webRoot": "${workspaceFolder}",
+			"sourceMaps": true,
+			"sourceMapPathOverrides": {
+				"webpack:///./src/*": "${webRoot}/src/*"
+			},
+			"runtimeArgs": ["--auto-open-devtools-for-tabs"]
+		}
+	],
+	"compounds": [
+		{
+			"name": "Debug SvelteKit",
+			"configurations": ["Start vite", "Launch Chrome"]
+		}
+	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug current TS file",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/vite-node",
+      "args": ["${relativeFile}"],
+      "cwd": "${workspaceFolder}",
+      "internalConsoleOptions": "openOnSessionStart",
+      "skipFiles": ["<node_internals>/**", "node_modules/**"],
+      "env": {
+        "TS_NODE_PROJECT": "${workspaceFolder}/tsconfig.json"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Start vite",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--", "--port", "4000"],
+      "skipFiles": ["<node_internals>/**"],
+      "console": "integratedTerminal"
+    },
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome",
+      "url": "http://localhost:4000",
+      "webRoot": "${workspaceFolder}",
+      "sourceMaps": true,
+      "sourceMapPathOverrides": {
+        "webpack:///./src/*": "${webRoot}/src/*"
+      },
+      "runtimeArgs": ["--auto-open-devtools-for-tabs"]
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Debug SvelteKit",
+      "configurations": ["Start vite", "Launch Chrome"]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,8 @@
 				"thememirror": "^2.0.1",
 				"tslib": "^2.4.1",
 				"typescript": "^5.0.0",
-				"vite": "^5.0.3"
+				"vite": "^5.0.3",
+				"vite-node": "^2.0.5"
 			},
 			"optionalDependencies": {
 				"@sveltejs/adapter-cloudflare": "^4.2.1"
@@ -3070,6 +3071,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/cacache": {
 			"version": "16.1.3",
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
@@ -3785,9 +3795,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+			"integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
 			"devOptional": true,
 			"dependencies": {
 				"ms": "2.1.2"
@@ -7107,6 +7117,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+			"dev": true
+		},
 		"node_modules/pe-library": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.0.tgz",
@@ -9057,6 +9073,15 @@
 				"globrex": "^0.1.2"
 			}
 		},
+		"node_modules/tinyrainbow": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+			"integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/tmp": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
@@ -9344,6 +9369,28 @@
 				"terser": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vite-node": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.5.tgz",
+			"integrity": "sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==",
+			"dev": true,
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.3.5",
+				"pathe": "^1.1.2",
+				"tinyrainbow": "^1.2.0",
+				"vite": "^5.0.0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/vite/node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
 		"thememirror": "^2.0.1",
 		"tslib": "^2.4.1",
 		"typescript": "^5.0.0",
-		"vite": "^5.0.3"
+		"vite": "^5.0.3",
+		"vite-node": "^2.0.5"
 	},
 	"optionalDependencies": {
 		"@sveltejs/adapter-cloudflare": "^4.2.1"


### PR DESCRIPTION
I expect these debuggers to be a bit flaky, but they work.

The SvelteKit debugger appears to work fine but it fires up an instance of Chrome as the debug server, this takes _several_ seconds to load and re-optimize the project's dependencies.