### PR TITLE
fix: disallow clearing the language input

### DIFF
--- a/src/lib/components/FieldSelect.svelte
+++ b/src/lib/components/FieldSelect.svelte
@@ -14,6 +14,8 @@
 	export let options: OptionOrGroup[] = [];
 	export let value: string | undefined = undefined;
 	export let placeholder: string = '';
+	export let allowClear: boolean = true;
+	export let allowSearch: boolean = true;
 	export let onChange: (value: Option) => void = () => {};
 
 	type Option = Selected<string> & { badge?: string };
@@ -99,10 +101,11 @@
 				id={name}
 				disabled={isDisabled}
 				aria-labelledby={`${name}-label`}
+				readonly={allowSearch ? null : true}
 			/>
 
 			<nav class="field-select-nav">
-				{#if selected?.value}
+				{#if allowClear && selected?.value}
 					<Button
 						variant="icon"
 						on:click={handleClear}

--- a/src/routes/settings/Interface.svelte
+++ b/src/routes/settings/Interface.svelte
@@ -24,6 +24,8 @@
 		name="language"
 		label={$LL.language()}
 		bind:value
+		allowClear={false}
+		allowSearch={false}
 		onChange={() => changeLanguage(value)}
 		options={[
 			{ value: 'en', label: 'English' },


### PR DESCRIPTION
Added an `allowClear` prop to `FieldSelect`, which defaults to true but is set to false in this case.