### PR TITLE
ui: change Hollama branding to CCN-chat

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="/fonts/inter/inter.css" />
 		<link rel="stylesheet" href="/fonts/jetbrains-mono/jetbrains-mono.css" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
-		<title>Hollama</title>
+		<title>CCN-chat</title>
 		%sveltekit.head%
 	</head>
 	<script>

--- a/src/lib/components/CollapsibleSidebar.svelte
+++ b/src/lib/components/CollapsibleSidebar.svelte
@@ -67,8 +67,8 @@
 		>
 			<div class="flex items-center justify-between border-b py-4">
 				<a href="/" class="mx-auto flex items-center gap-2 pr-4">
-					<img class="h-8 w-8" src="/favicon.png" alt="Hollama logo" />
-					<span class="text-lg font-semibold tracking-tight">Hollama</span>
+					<img class="h-8 w-8" src="/favicon.png" alt="CCN-chat logo" />
+					<span class="text-lg font-semibold tracking-tight">CCN-chat</span>
 				</a>
 			</div>
 
@@ -187,7 +187,7 @@
 				</a>
 
 				<a
-					href="https://github.com/fmaclen/hollama"
+					href="https://github.com/ccn-chat/ccn-chat"
 					target="_blank"
 					rel="noopener noreferrer"
 					class="duration-25 flex items-center gap-3 px-4 py-3 text-sm font-medium text-muted transition-colors hover:text-active"

--- a/src/lib/components/CollapsibleSidebar.svelte
+++ b/src/lib/components/CollapsibleSidebar.svelte
@@ -187,7 +187,7 @@
 				</a>
 
 				<a
-					href="https://github.com/ccn-chat/ccn-chat"
+					href="https://github.com/claremont-computer-network/hollama-ccn"
 					target="_blank"
 					rel="noopener noreferrer"
 					class="duration-25 flex items-center gap-3 px-4 py-3 text-sm font-medium text-muted transition-colors hover:text-active"

--- a/src/lib/components/Head.svelte
+++ b/src/lib/components/Head.svelte
@@ -4,8 +4,8 @@
 	export let title: LocalizedString | LocalizedString[] | string | string[] | undefined = undefined;
 	const SEPARATOR = ' • ';
 	$: formattedTitle = title
-		? (Array.isArray(title) ? title.join(SEPARATOR) : title) + SEPARATOR + 'Hollama'
-		: 'Hollama';
+		? (Array.isArray(title) ? title.join(SEPARATOR) : title) + SEPARATOR + 'CCN-chat'
+		: 'CCN-chat';
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary
This PR updates all UI instances of \"Hollama\" to \"CCN-chat\" in preparation for the rebranding.

## Changes
- `src/lib/components/CollapsibleSidebar.svelte`: Updated logo alt text and sidebar title
- `src/lib/components/Head.svelte`: Updated page title suffix
- `src/app.html`: Updated default HTML title
- Updated GitHub link to point to the ccn-chat/ccn-chat repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)