### PR TITLE
Add Ollama thinking stream support

### DIFF
--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -23,7 +23,7 @@ export interface ChatStrategy {
 	chat(
 		payload: ChatRequest,
 		abortSignal: AbortSignal,
-		onChunk: (content: string) => void
+		onChunk: (part: { content?: string; thinking?: string }) => void
 	): Promise<void>;
 
 	getModels(): Promise<Model[]>;

--- a/src/lib/chat/openai.ts
+++ b/src/lib/chat/openai.ts
@@ -23,7 +23,7 @@ export class OpenAIStrategy implements ChatStrategy {
 	async chat(
 		payload: ChatRequest,
 		abortSignal: AbortSignal,
-		onChunk: (content: string) => void
+		onChunk: (part: { content?: string; thinking?: string }) => void
 	): Promise<void> {
 		const formattedMessages = payload.messages.map(
 			(message: Message): ChatCompletionMessageParam => {
@@ -68,7 +68,8 @@ export class OpenAIStrategy implements ChatStrategy {
 
 		for await (const chunk of response) {
 			if (abortSignal.aborted) break;
-			onChunk(chunk.choices[0].delta.content || '');
+			const text = chunk.choices[0].delta.content || '';
+			if (text) onChunk({ content: text });
 		}
 	}
 

--- a/src/routes/sessions/[id]/+page.svelte
+++ b/src/routes/sessions/[id]/+page.svelte
@@ -209,10 +209,15 @@
 				}
 			);
 
-			await strategy.chat(chatRequest, editor.abortController.signal, async (chunk) => {
-				// Process the chunk using the FSM-based processor
-				reasoningProcessor.processChunk(chunk);
-				await scrollToBottom();
+			await strategy.chat(chatRequest, editor.abortController.signal, async (part) => {
+				if (part.thinking != null) {
+					editor.reasoning += part.thinking;
+					await scrollToBottom();
+				}
+				if (part.content != null) {
+					reasoningProcessor.processChunk(part.content);
+					await scrollToBottom();
+				}
 			});
 
 			// Finalize processing of any remaining content


### PR DESCRIPTION
- Send think: true to /api/chat for reasoning models
- Stream message.thinking and message.content separately
- Show thinking in collapsible Reasoning section (qwen3, deepseek-r1, etc.)